### PR TITLE
Specify hop_length and n_fft parameters to extract MFCC with duration…

### DIFF
--- a/script_create_features_files.py
+++ b/script_create_features_files.py
@@ -39,7 +39,9 @@ def extract_features(path_to_wavs, feat_func, path_to_save):
             waveform = waveform.astype(float)
             print(filename, waveform.shape)
             if feat_func == 'mfccs':
-                feat = librosa.feature.mfcc(y=waveform, sr=fs, S=None, n_mfcc=13, fmin = 0, fmax = 8000) 
+                feat = librosa.feature.mfcc(y=waveform, sr=fs, S=None, n_mfcc=13, fmin=0, fmax=8000,
+                                            n_fft=int(0.025 * fs),
+                                            hop_length=int(0.01 * fs))
                 feat_delta = librosa.feature.delta(feat)
                 feat_delta_2 = librosa.feature.delta(feat, order=2)
                 feat = np.swapaxes(np.concatenate((feat, feat_delta,


### PR DESCRIPTION
This PR modifies `script_create_features_files` so that it extracts MFCCs features based on a window whose duration is 0.025s and that is shifted by 0.01s.